### PR TITLE
Make PNG support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,8 @@ readme = "README.md"
 
 [dependencies]
 byteorder = "1"
-png = "0.11"
+png = { version = "0.11", optional = true }
+
+[features]
+default = ["pngio"]
+pngio = ["png"]

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,6 +1,6 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::cmp;
-use std::io::{self, Cursor, Error, ErrorKind, Read, Write};
+use std::io::{self, Error, ErrorKind, Read, Write};
 
 use super::icontype::{Encoding, IconType, OSType};
 use super::image::{Image, PixelFormat};
@@ -9,6 +9,7 @@ use super::image::{Image, PixelFormat};
 const ICON_ELEMENT_HEADER_LENGTH: u32 = 8;
 
 /// The first twelve bytes of a JPEG 2000 file are always this:
+#[cfg(feature = "pngio")]
 const JPEG_2000_FILE_MAGIC_NUMBER: [u8; 12] =
     [0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50, 0x20, 0x20, 0x0D, 0x0A, 0x87, 0x0A];
 
@@ -60,10 +61,13 @@ impl IconElement {
         }
         let mut data: Vec<u8>;
         match icon_type.encoding() {
+            #[cfg(feature = "pngio")]
             Encoding::JP2PNG => {
                 data = Vec::new();
-                try!(image.write_png(&mut data));
+                image.write_png(&mut data)?;
             }
+            #[cfg(not(feature = "pngio"))]
+            Encoding::JP2PNG => unimplemented!(),
             Encoding::RLE24 => {
                 let num_pixels = (width * height) as usize;
                 match image.pixel_format() {
@@ -110,13 +114,14 @@ impl IconElement {
         let width = icon_type.pixel_width();
         let height = icon_type.pixel_width();
         match icon_type.encoding() {
+            #[cfg(feature = "pngio")]
             Encoding::JP2PNG => {
                 if self.data.starts_with(&JPEG_2000_FILE_MAGIC_NUMBER) {
                     let msg = "element to be decoded contains JPEG 2000 \
                                data, which is not yet supported";
                     return Err(Error::new(ErrorKind::InvalidInput, msg));
                 }
-                let image = try!(Image::read_png(Cursor::new(&self.data)));
+                let image = try!(Image::read_png(io::Cursor::new(&self.data)));
                 if image.width() != width || image.height() != height {
                     let msg = format!("decoded PNG has wrong dimensions \
                                        ({}x{} instead of {}x{})",
@@ -128,6 +133,8 @@ impl IconElement {
                 }
                 Ok(image)
             }
+            #[cfg(not(feature = "pngio"))]
+            Encoding::JP2PNG => unimplemented!(),
             Encoding::RLE24 => {
                 let mut image = Image::new(PixelFormat::RGB, width, height);
                 try!(decode_rle(&self.data, 3, image.data_mut()));

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,5 @@
-use png;
-use png::HasParameters;
 use std;
-use std::io::{self, Read, Write};
+use std::io;
 
 /// A decoded icon image.
 ///
@@ -16,10 +14,10 @@ use std::io::{self, Read, Write};
 /// bottom-right pixel comes last).
 #[derive(Clone)]
 pub struct Image {
-    format: PixelFormat,
-    width: u32,
-    height: u32,
-    data: Box<[u8]>,
+    pub(crate) format: PixelFormat,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) data: Box<[u8]>,
 }
 
 impl Image {
@@ -150,60 +148,6 @@ impl Image {
             height: self.height,
             data: new_data,
         }
-    }
-
-    /// Reads an image from a PNG file.
-    pub fn read_png<R: Read>(input: R) -> io::Result<Image> {
-        let decoder = png::Decoder::new(input);
-        let (info, mut reader) = try!(decoder.read_info());
-        let pixel_format = match info.color_type {
-            png::ColorType::RGBA => PixelFormat::RGBA,
-            png::ColorType::RGB => PixelFormat::RGB,
-            png::ColorType::GrayscaleAlpha => PixelFormat::GrayAlpha,
-            png::ColorType::Grayscale => PixelFormat::Gray,
-            _ => {
-                // TODO: Support other color types.
-                return Err(io::Error::new(io::ErrorKind::InvalidData,
-                                          format!("unsupported PNG color \
-                                                   type: {:?}",
-                                                  info.color_type)));
-            }
-        };
-        if info.bit_depth != png::BitDepth::Eight {
-            // TODO: Support other bit depths.
-            return Err(io::Error::new(io::ErrorKind::InvalidData,
-                                      format!("unsupported PNG bit depth: \
-                                               {:?}",
-                                              info.bit_depth)));
-
-        }
-        let mut image = Image::new(pixel_format, info.width, info.height);
-        assert_eq!(image.data().len(), info.buffer_size());
-        try!(reader.next_frame(image.data_mut()));
-        Ok(image)
-    }
-
-    /// Writes the image to a PNG file.
-    pub fn write_png<W: Write>(&self, output: W) -> io::Result<()> {
-        let color_type = match self.format {
-            PixelFormat::RGBA => png::ColorType::RGBA,
-            PixelFormat::RGB => png::ColorType::RGB,
-            PixelFormat::GrayAlpha => png::ColorType::GrayscaleAlpha,
-            PixelFormat::Gray => png::ColorType::Grayscale,
-            PixelFormat::Alpha => {
-                return self.convert_to(PixelFormat::GrayAlpha)
-                    .write_png(output);
-            }
-        };
-        let mut encoder = png::Encoder::new(output, self.width, self.height);
-        encoder.set(color_type).set(png::BitDepth::Eight);
-        let mut writer = try!(encoder.write_header());
-        writer.write_image_data(&self.data).map_err(|err| match err {
-            png::EncodingError::IoError(err) => err,
-            png::EncodingError::Format(msg) => {
-                io::Error::new(io::ErrorKind::InvalidData, msg.into_owned())
-            }
-        })
     }
 }
 
@@ -717,6 +661,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pngio")]
     fn write_grayscale_png() {
         let gray_data: Vec<u8> = vec![63, 127, 191, 255];
         let mut image = Image::new(PixelFormat::Gray, 2, 2);
@@ -733,6 +678,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pngio")]
     fn write_rgb_png() {
         let rgb_data: Vec<u8> = vec![255, 0, 0, 0, 255, 0, 0, 0, 255, 127,
                                      127, 127];
@@ -751,6 +697,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pngio")]
     fn write_rgba_png() {
         let rgba_data: Vec<u8> = vec![255, 0, 0, 63, 0, 255, 0, 127, 0, 0,
                                       255, 191, 127, 127, 127, 255];
@@ -769,6 +716,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pngio")]
     fn read_rgba_png() {
         let png: Vec<u8> =
             vec![137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68,
@@ -788,6 +736,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pngio")]
     fn png_round_trip() {
         let rgba_data: Vec<u8> = vec![127, 0, 0, 63, 0, 191, 0, 127, 0, 0,
                                       255, 191, 127, 127, 127, 255];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,12 @@
 #![warn(missing_docs)]
 
 extern crate byteorder;
+
+#[cfg(feature = "pngio")]
 extern crate png;
+
+#[cfg(feature = "pngio")]
+mod pngio;
 
 mod element;
 pub use self::element::IconElement;

--- a/src/pngio.rs
+++ b/src/pngio.rs
@@ -1,0 +1,61 @@
+use png;
+use png::HasParameters;
+use std::io::{self, Read, Write};
+use image::{Image, PixelFormat};
+
+impl Image {
+
+    /// Reads an image from a PNG file.
+    pub fn read_png<R: Read>(input: R) -> io::Result<Image> {
+        let decoder = png::Decoder::new(input);
+        let (info, mut reader) = try!(decoder.read_info());
+        let pixel_format = match info.color_type {
+            png::ColorType::RGBA => PixelFormat::RGBA,
+            png::ColorType::RGB => PixelFormat::RGB,
+            png::ColorType::GrayscaleAlpha => PixelFormat::GrayAlpha,
+            png::ColorType::Grayscale => PixelFormat::Gray,
+            _ => {
+                // TODO: Support other color types.
+                return Err(io::Error::new(io::ErrorKind::InvalidData,
+                                          format!("unsupported PNG color \
+                                                   type: {:?}",
+                                                  info.color_type)));
+            }
+        };
+        if info.bit_depth != png::BitDepth::Eight {
+            // TODO: Support other bit depths.
+            return Err(io::Error::new(io::ErrorKind::InvalidData,
+                                      format!("unsupported PNG bit depth: \
+                                               {:?}",
+                                              info.bit_depth)));
+
+        }
+        let mut image = Image::new(pixel_format, info.width, info.height);
+        assert_eq!(image.data().len(), info.buffer_size());
+        try!(reader.next_frame(image.data_mut()));
+        Ok(image)
+    }
+
+    /// Writes the image to a PNG file.
+    pub fn write_png<W: Write>(&self, output: W) -> io::Result<()> {
+        let color_type = match self.format {
+            PixelFormat::RGBA => png::ColorType::RGBA,
+            PixelFormat::RGB => png::ColorType::RGB,
+            PixelFormat::GrayAlpha => png::ColorType::GrayscaleAlpha,
+            PixelFormat::Gray => png::ColorType::Grayscale,
+            PixelFormat::Alpha => {
+                return self.convert_to(PixelFormat::GrayAlpha)
+                    .write_png(output);
+            }
+        };
+        let mut encoder = png::Encoder::new(output, self.width, self.height);
+        encoder.set(color_type).set(png::BitDepth::Eight);
+        let mut writer = try!(encoder.write_header());
+        writer.write_image_data(&self.data).map_err(|err| match err {
+            png::EncodingError::IoError(err) => err,
+            png::EncodingError::Format(msg) => {
+                io::Error::new(io::ErrorKind::InvalidData, msg.into_owned())
+            }
+        })
+    }
+}


### PR DESCRIPTION
I want to use a different PNG encoder, and I'd rather not have two in one application, so I've made the built-in one optional.

