### PR TITLE
Update png library version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 byteorder = "1"
-png = { version = "0.13", optional = true }
+png = { version = "0.16", optional = true }
 
 [features]
 default = ["pngio"]

--- a/src/pngio.rs
+++ b/src/pngio.rs
@@ -1,5 +1,4 @@
 use png;
-use png::HasParameters;
 use std::io::{self, Read, Write};
 use image::{Image, PixelFormat};
 
@@ -49,7 +48,8 @@ impl Image {
             }
         };
         let mut encoder = png::Encoder::new(output, self.width, self.height);
-        encoder.set(color_type).set(png::BitDepth::Eight);
+        encoder.set_color(color_type);
+        encoder.set_depth(png::BitDepth::Eight);
         let mut writer = encoder.write_header()?;
         writer.write_image_data(&self.data).map_err(|err| match err {
             png::EncodingError::IoError(err) => err,


### PR DESCRIPTION
Some of the benefits: better speed, encoding fixes, etc.

Background: we may want to hook the library up in `image`.