### PR TITLE
Add mode for icns2png to extract all types

### DIFF
--- a/examples/icns2png.rs
+++ b/examples/icns2png.rs
@@ -31,7 +31,7 @@ use std::str::FromStr;
 fn main() {
     let num_args = env::args().count();
     if num_args < 2 || num_args > 3 {
-        println!("Usage: icns2png <path> [<ostype>]");
+        println!("Usage: icns2png <path> [<ostype>|all]");
         return;
     }
     let icns_path = env::args().nth(1).unwrap();
@@ -40,12 +40,17 @@ fn main() {
         .expect("failed to open ICNS file"));
     let family = IconFamily::read(icns_file)
         .expect("failed to read ICNS file");
-    let (icon_type, png_path) = if num_args == 3 {
-        let ostype = OSType::from_str(&env::args().nth(2).unwrap()).unwrap();
-        let icon_type = IconType::from_ostype(ostype)
+
+    let (icon_type, typed_filename) = if num_args == 3 {
+        let type_name = &env::args().nth(2).unwrap();
+        if type_name == "all" {
+            (None, true)
+        } else {
+            let ostype = OSType::from_str(type_name).unwrap();
+            let icon_type = IconType::from_ostype(ostype)
             .expect("unsupported ostype");
-        let png_path = icns_path.with_extension(format!("{}.png", ostype));
-        (icon_type, png_path)
+            (Some(icon_type), true)
+        }
     } else {
         // If no OSType is specified, extract the highest-resolution icon.
         let &icon_type = family.available_icons()
@@ -54,12 +59,33 @@ fn main() {
                 icon_type.pixel_width() * icon_type.pixel_height()
             })
             .expect("ICNS file contains no icons");
-        let png_path = icns_path.with_extension("png");
-        (icon_type, png_path)
+        (Some(icon_type), true)
     };
-    let image = family.get_icon_with_type(icon_type)
-        .expect("ICNS file does not contain that icon type");
-    let png_file = BufWriter::new(File::create(png_path)
-        .expect("failed to create PNG file"));
-    image.write_png(png_file).expect("failed to write PNG file");
+
+    if let Some(icon_type) = icon_type {
+        // Extract specific icon
+        let image = family.get_icon_with_type(icon_type)
+            .expect("ICNS file does not contain that icon type");
+        let ext = if typed_filename {
+            format!("{}.png", icon_type.ostype())
+        } else {
+            "png".to_string()
+        };
+        let png_path = icns_path.with_extension(ext);
+
+        let png_file = BufWriter::new(File::create(png_path)
+            .expect("failed to create PNG file"));
+        image.write_png(png_file).expect("failed to write PNG file");
+
+    } else {
+        // Extract all icons (assuming no duplicates)
+        for icon_type in family.available_icons() {
+            let image = family.get_icon_with_type(icon_type)
+                .expect("ICNS file does not contain that icon type");
+            let png_path = icns_path.with_extension(format!("{}.png", icon_type.ostype()));
+            let png_file = BufWriter::new(File::create(png_path)
+                .expect("failed to create PNG file"));
+            image.write_png(png_file).expect("failed to write PNG file");
+        }
+    }
 }


### PR DESCRIPTION
I've found this extension to `icns2png` to be useful when testing the library against existing icns files, which usually have many entries that are inconvenient to extract one by one.