### PR TITLE
Derive Ord for IconType and other enums

### DIFF
--- a/src/icontype.rs
+++ b/src/icontype.rs
@@ -11,7 +11,7 @@ use std::fmt;
 /// [decode](struct.IconFamily.html#method.get_icon_with_type) complete icons
 /// that consist of multiple `IconElements`.
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum IconType {
     /// 32x32 1-bit icon (without alpha)
     Mono_32x32,
@@ -520,7 +520,7 @@ impl std::str::FromStr for OSType {
 /// (This type is used internally by the library, but is irrelvant to most
 /// library users; if you're not sure whether you need to use it, you probably
 /// don't.)
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Encoding {
     /// Icon element data payload is an uncompressed one bit image
     Mono,

--- a/src/image.rs
+++ b/src/image.rs
@@ -160,7 +160,7 @@ impl Image {
 /// first, followed by the rest of the top row from left to right; then comes
 /// the second row down, again from left to right, and so on until finally the
 /// bottom-right pixel comes last).
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum PixelFormat {
     /// 32-bit color with alpha channel.  Each pixel is four bytes, with red
     /// first and alpha last.


### PR DESCRIPTION
This makes it a bit more convenient to use an IconType as the key for a BTreeMap or sorted array. (In [`image-extras`](https://github.com/image-rs/image-extras/blob/abc9dbb9c363ce1ee583152819675495ee87b516/src/icns.rs#L335) I ended up using a HashMap just to keep the code simple, but it's arguably overkill.) I've added `Ord` to the other two enums mainly for completeness, but don't see an immediate use for it.